### PR TITLE
Reformatted relative import for _version

### DIFF
--- a/src/pinknoise/__init__.py
+++ b/src/pinknoise/__init__.py
@@ -1,4 +1,4 @@
-from _version import __version__
+from ._version import __version__
 __all__ = ['compute', 'utils']
 
 from .compute import *


### PR DESCRIPTION
The Python3 relative import requires the decimal before the `_version` in `from ._version import __version__`. 

I had to make the adjustment on my clone in order to import the library after running `python setup.py install`.

Otherwise, the import resulted in the following error:

```python
----> 1 from _version import __version__
      2 __all__ = ['compute', 'utils']
      4 from .compute import *

ModuleNotFoundError: No module named '_version'
```