### PR TITLE
Added stochastic to install_requires list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='pinknoise',
       license='MIT',
       packages=['pinknoise'],
       package_dir={'pinknoise': 'src/pinknoise'},
-      install_requires=['numpy','scipy'],
+      install_requires=['numpy','scipy', 'stochastic'],
       python_requires='>=3.0',
       ext_modules = [module],
       zip_safe=False)


### PR DESCRIPTION
After installing via `python setup.py install`, I recieved the following error:

``python
ModuleNotFoundError: No module named 'stochastic'
```

Adding the `stochastic` module to the required packages solved this problem